### PR TITLE
Add missing conversion class from vector of WheelTelemetryData to Python list

### DIFF
--- a/PythonAPI/carla/source/libcarla/Control.cpp
+++ b/PythonAPI/carla/source/libcarla/Control.cpp
@@ -614,6 +614,11 @@ void export_control() {
     .def(self_ns::str(self_ns::self))
   ;
 
+   class_<std::vector<carla::rpc::WheelTelemetryData> >("vector_of_wheels_telemetry")
+     .def(vector_indexing_suite<std::vector<carla::rpc::WheelTelemetryData> >())
+     .def(self_ns::str(self_ns::self))
+   ;
+
   class_<cr::VehicleTelemetryData>("VehicleTelemetryData", no_init)
     .def("__init__", raw_function(VehicleTelemetryData_init))
     .def(init<>())


### PR DESCRIPTION
#### Description
Add missing conversion class from vector of WheelTelemetryData to Python list

This adds a missing conversion from vector of WheelTelemetryData to a Python list. When trying to access the "wheels" attribute of the VehicleTelemetryData without this, this exception will occur:

TypError: No to_python (by-value) converter found for C++ type: std::vector<carla::rpc::WheelTelemetryData, std::allocator<carla::rpc::WheelTelemetryData>>

This addition fixes this issue to make the usage in line with similar classes such as "VehiclePhysicsControl" and "WheelPhysicsControl" 

Checklist:

  - [x] Your branch is up-to-date with the `dev` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [x] If relevant, update CHANGELOG.md with your changes

#### Where has this been tested?

  * **Platform(s):** Linux
  * **Python version(s):** 3.10.12
  * **Unreal Engine version(s):** 4.26.2.0